### PR TITLE
make force_destroy optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,10 +15,15 @@ variable "tags" {
   type = "map"
 }
 
+# whether or not to set force_destroy on the bucket
+variable "force_destroy" {
+  default = "true"
+}
+
 # bucket for storing tf state
 resource "aws_s3_bucket" "bucket" {
   bucket        = "tf-state-${var.application}"
-  force_destroy = "true"
+  force_destroy = "${var.force_destroy}"
 
   versioning {
     enabled = "true"


### PR DESCRIPTION
Having `force_destroy` on all the time on the state bucket seems potentially dangerous in production scenarios. This change leaves it defaulting to true but allows the importing TF to set it to false instead.