### PR TITLE
add support for granting additional roles access to bucket

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Turner
+Copyright 2017-2020 Turner/WarnerMedia, a division of AT&T
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,11 @@ Useful for creating a common bucket naming convention and attaching a bucket pol
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | application | the application that will be using this remote state | string | - | yes |
-| multipart_days |  | string | `3` | no |
-| multipart_delete | incomplete multipart upload deletion | string | `true` | no |
-| role | the role that will be used to access the tf remote state | string | - | yes |
-| tags | tags | map | - | yes |
+| multipart\_days |  | string | `3` | no |
+| multipart\_delete | incomplete multipart upload deletion | string | `true` | no |
+| role | the primary role that will be used to access the tf remote state | string | - | yes |
+| additional\_roles | additional roles that will be granted access to the remote state | list of strings | \[] | no |
+| tags | tags to apply the created S3 bucket | map | - | yes |
 
 ## Outputs
 
@@ -33,7 +34,7 @@ provider "aws" {
 }
 
 module "tf_remote_state" {
-  source = "github.com/turnerlabs/terraform-remote-state?ref=v3.0.0"
+  source = "github.com/turnerlabs/terraform-remote-state?ref=v3.1.0"
 
   role          = "aws-ent-prod-devops"
   application   = "my-test-app"


### PR DESCRIPTION
Adds ability to grant access to the created bucket to more than one IAM role. To preserve compatibility with older versions, the single parameter **role** is still a string, but there's a new parameter **additional_roles** which is a list of strings, all of which are expected to be role names which are resolved into ARNs and included in the policy alongside the value of **role**.