### PR TITLE
Work around lifecycle bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,11 @@ resource "aws_s3_bucket" "bucket" {
     prefix                                 = ""
     enabled                                = var.multipart_delete
     abort_incomplete_multipart_upload_days = var.multipart_days
+
+    # required to keep tf from thinking it needs to change things later
+    expiration {
+        expired_object_delete_marker = false
+    }
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ provider "aws" {
 }
 
 module "tf_remote_state" {
-  source = "github.com/turnerlabs/terraform-remote-state?ref=v4.0.0"
+  source = "github.com/turnerlabs/terraform-remote-state?ref=v4.0.1"
 
   role          = "aws-ent-prod-devops"
   application   = "my-test-app"


### PR DESCRIPTION
The TF AWS provider has [a bug](https://github.com/terraform-providers/terraform-provider-aws/issues/14603) that requires lifecycle_rules to include an expiration or transition block; this adds a do-nothing expiration block to avoid tickling that bug and causing `terraform plan` to think it needs to change the bucket lifecycle config every time it is run. As a workaround this fixes #12.