### PR TITLE
Work around sequencing bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,8 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_public_access_block" "bucket" {
   count = var.block_public_access ? 1 : 0
 
+  depends_on = [aws_s3_bucket_policy.bucket_policy]
+
   bucket                  = aws_s3_bucket.bucket.id
   block_public_acls       = true
   block_public_policy     = true
@@ -97,6 +99,8 @@ data "aws_iam_role" "additional_roles" {
 
 # grant the role access to the bucket
 resource "aws_s3_bucket_policy" "bucket_policy" {
+
+  depends_on = [aws_s3_bucket.bucket]
   bucket = aws_s3_bucket.bucket.id
 
   policy = <<EOF

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ provider "aws" {
 }
 
 module "tf_remote_state" {
-  source = "github.com/turnerlabs/terraform-remote-state?ref=v4.0.1"
+  source = "github.com/turnerlabs/terraform-remote-state?ref=v4.0.2"
 
   role          = "aws-ent-prod-devops"
   application   = "my-test-app"


### PR DESCRIPTION
Adds explicit ordering to the creations of the three resources (bucket -> bucket policy -> public-access block) to work around upstream issue reported at https://github.com/terraform-providers/terraform-provider-aws/issues/7628.  Fixes #14.