### PR TITLE
Dynamodb state locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provider. In general it's a good idea always to reference the module with an exp
 | Name | Description |
 |------|-------------|
 | bucket | the created bucket |
-
+| dynamodb_lock_table | name of dynamodb lock table, if created |
 
 #### usage example
 

--- a/main.tf
+++ b/main.tf
@@ -110,10 +110,8 @@ resource "aws_dynamodb_table" "state_lock_table" {
   count = var.dynamodb_state_locking ? 1 : 0
 
   name           = "tf-state-lock-${var.application}"
-  billing_mode   = "PROVISIONED"
+  billing_mode   = "PAY_PER_REQUEST"
   hash_key       = "LockID"
-  write_capacity = 1
-  read_capacity  = 1
 
   tags           = var.tags
 
@@ -172,5 +170,5 @@ output "bucket" {
 
 # dynamodb table
 output "dynamodb_lock_table" {
-    value = var.dynamodb_state_locking ? aws_dynamodb_table.state_lock_table[0].id : null
+    value = var.dynamodb_state_locking ? aws_dynamodb_table.state_lock_table[0].name : null
 }


### PR DESCRIPTION
Terraform's s3 backend supports using a dynamodb table to store lock status. We have a project that needs to use it as we can have multiple instances of terraform apply running at the same time and don't want to corrupt the state file.

Instead of just creating a table in our repo, I decided to open up a PR to add an optional flag that will make the base module create a dynamodb with the correct attributes set. 

https://www.terraform.io/language/settings/backends/s3#dynamodb-state-locking