### PR TITLE
Add explicit bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### terraform-remote-state
 
+Current release: v5.2.0
+
 A Terraform module that configures an s3 bucket for use with Terraform's remote state feature.
 
 Useful for creating a common bucket naming convention and attaching a bucket policy using the specified role.
@@ -48,7 +50,7 @@ terraform {
 }
 
 module "tf_remote_state" {
-  source = "github.com/turnerlabs/terraform-remote-state?ref=v5.1.0"
+  source = "github.com/turnerlabs/terraform-remote-state?ref=v5.2.0"
 
   role          = "aws-ent-prod-devops"
   application   = "my-test-app"

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,14 @@ resource "aws_dynamodb_table" "state_lock_table" {
   }
 }
 
+# grant bucket owner full control of all objects; disable per-object ACLs
+resource "aws_s3_bucket_ownership_controls" "bucket_owner" {
+    bucket = aws_s3_bucket.bucket.id
+    rule {
+      object_ownership = "BucketOwnerPreferred"
+    }
+}
+
 # lookup the role arn
 data "aws_iam_role" "role" {
   name = var.role
@@ -131,7 +139,7 @@ data "aws_iam_role" "additional_roles" {
   name = each.key
 }
 
-# grant the role access to the bucket
+# grant the roles access to the bucket
 resource "aws_s3_bucket_policy" "bucket_policy" {
 
   depends_on = [aws_s3_bucket.bucket]


### PR DESCRIPTION
Disable per-object ACLs explicitly (this will be the default behavior if left unspecified starting in April 2023).